### PR TITLE
Add initial Hedera Sourcify Umbrella Chart

### DIFF
--- a/charts/hedera-sourcify-repository/Chart.yaml
+++ b/charts/hedera-sourcify-repository/Chart.yaml
@@ -1,24 +1,25 @@
 apiVersion: v2
-name: hedera-sourcify-repository
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+appVersion: "0.1.0-SNAPSHOT"
+description: Helm chart deployment of the hashgraph/sourcify repository product for Hedera (fork of ethereum/sourcify)
+home: https://github.com/hashgraph/hedera-sourcify
+icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
+keywords:
+  - blockchain
+  - dlt
+  - hedera
+  - hashgraph
+  - smart
+  - contracts
+  - verification
+  - verifier
+  - repository
+maintainers:
+  - name: Hedera Smart Contracts Team
+    email: engsmartcontracts@hedera.com
+  - name: Hedera Mirror Node Explorer Team
+    email: engsmartcontracts@hedera.com
+name: hedera-sourcify
+sources:
+  - https://github.com/hashgraph/hedera-sourcify
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+version: 0.1.0-SNAPSHOT

--- a/charts/hedera-sourcify-server/Chart.yaml
+++ b/charts/hedera-sourcify-server/Chart.yaml
@@ -1,24 +1,25 @@
 apiVersion: v2
-name: hedera-sourcify-server
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+appVersion: "0.1.0-SNAPSHOT"
+description: Helm chart deployment of the hashgraph/sourcify server product for Hedera (fork of ethereum/sourcify)
+home: https://github.com/hashgraph/hedera-sourcify
+icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
+keywords:
+  - blockchain
+  - dlt
+  - hedera
+  - hashgraph
+  - smart
+  - contracts
+  - verification
+  - verifier
+  - server
+maintainers:
+  - name: Hedera Smart Contracts Team
+    email: engsmartcontracts@hedera.com
+  - name: Hedera Mirror Node Explorer Team
+    email: engsmartcontracts@hedera.com
+name: hedera-sourcify
+sources:
+  - https://github.com/hashgraph/hedera-sourcify
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+version: 0.1.0-SNAPSHOT

--- a/charts/hedera-sourcify-ui/Chart.yaml
+++ b/charts/hedera-sourcify-ui/Chart.yaml
@@ -1,24 +1,25 @@
 apiVersion: v2
-name: hedera-sourcify-ui
-description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+appVersion: "0.1.0-SNAPSHOT"
+description: Helm chart deployment of the hashgraph/sourcify ui product for Hedera (fork of ethereum/sourcify)
+home: https://github.com/hashgraph/hedera-sourcify
+icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
+keywords:
+  - blockchain
+  - dlt
+  - hedera
+  - hashgraph
+  - smart
+  - contracts
+  - verification
+  - verifier
+  - ui
+maintainers:
+  - name: Hedera Smart Contracts Team
+    email: engsmartcontracts@hedera.com
+  - name: Hedera Mirror Node Explorer Team
+    email: engsmartcontracts@hedera.com
+name: hedera-sourcify
+sources:
+  - https://github.com/hashgraph/hedera-sourcify
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.16.0"
+version: 0.1.0-SNAPSHOT


### PR DESCRIPTION
**Description**:
To enable smooth deployment an umbrella helm chart is provided
- Main umbrella chart - hedera-sourcify
- dependency chart - hedera-sourcify- repository
- dependency chart - hedera-sourcify- server
- dependency chart - hedera-sourcify- ui

**Related issue(s)**:

Fixes #1 

**Notes for reviewer**:
Currently this is based off of the [POC docker-compose](https://github.com/svienot/sourcify/blob/keep-local/environments/docker-compose-2.yaml) and requires testing.

Additional considerations to be made for 
- [ ] github action for chart considerations
- [ ] IPFS
- [ ] Backup storage

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
