### PR TITLE
Add permissions to build workflow.

### DIFF
--- a/.github/workflows/release-image-to-github.yaml
+++ b/.github/workflows/release-image-to-github.yaml
@@ -8,12 +8,14 @@ permissions:
 
 env:
   OWNER: hashgraph
-  PACKAGE_NAME: source-verify
   REGISTRY: ghcr.io
 
 jobs:
   docker-image-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Adding permissions to release-image-to-github.yaml GH Actions workflow.