### PR TITLE
Regroup permissions under job.

### DIFF
--- a/.github/workflows/release-image-to-github.yaml
+++ b/.github/workflows/release-image-to-github.yaml
@@ -3,9 +3,6 @@ name: Release Docker Image to GitHub
 on:
   workflow_dispatch:
 
-permissions:
-  packages: write
-
 env:
   OWNER: hashgraph
   REGISTRY: ghcr.io
@@ -14,8 +11,9 @@ jobs:
   docker-image-publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: read
+      id-token: write
+      packages: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fix release-image-to-github.yaml workflow by regrouping permissions under job.