### PR TITLE
Make URL of sourcify server and repository configurable

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -20,3 +20,8 @@ RUN npm run build
 FROM nginx:alpine
 COPY --from=builder /home/node/app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy entrypoint
+COPY ui-entrypoint.sh /docker-entrypoint.d/
+RUN chmod +x /docker-entrypoint.d/ui-entrypoint.sh
+

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -20,6 +20,12 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>sourcify.eth</title>
+    <script>
+      // CONFIGURATION_PLACEHOLDER
+      // This comment will be removed at build time. The Docker entrypoint will
+      // look for this empty script element and insert the definition of configuration
+      // parameter(s) passed via the global window object.
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -1,6 +1,23 @@
+declare global {
+  interface Window {
+    // adding custom properties
+    configs: {
+      REPOSITORY_SERVER_URL: string,
+      SERVER_URL: string,
+    }
+  }
+}
+
 export const REPOSITORY_SERVER_URL =
-  process.env.REACT_APP_REPOSITORY_SERVER_URL;
-export const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+  window.configs?.REPOSITORY_SERVER_URL?.length > 0
+    ? window.configs.REPOSITORY_SERVER_URL
+    : process.env.REACT_APP_REPOSITORY_SERVER_URL
+
+export const SERVER_URL =
+  window.configs?.SERVER_URL?.length > 0
+    ? window.configs.SERVER_URL
+    : process.env.REACT_APP_SERVER_URL
+
 export const DOCS_URL = "https://docs.hedera.com";
 export const PLAYGROUND_URL = "https://playground.sourcify.dev";
 export const HASHSCAN_URL = "https://hashscan-latest.hedera-devops.com/"

--- a/ui/ui-entrypoint.sh
+++ b/ui/ui-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Patch index.html to insert config parameter in the global window object
+sed -i "s@<script></script>@<script>window.configs={SERVER_URL:\"${SERVER_URL}\",REPOSITORY_SERVER_URL:\"${REPOSITORY_SERVER_URL}\"}</script>@" /usr/share/nginx/html/index.html
+
+# Start nginx
+nginx -g "daemon off;"


### PR DESCRIPTION
**Description**:

These changes allow to configure the URL of the server and repository services via runtime environment variables:

- the URL of the server and repository can be defined with the $SERVER_URL and $REPOSITORY_SERVER_URL environment variables
- the Docker ui-entrypoint.sh is used to insert a piece of script in the index.html of the select form. This script uses the value of $SERVER_URL and $REPOSITORY_SERVER_URL to set corresponding custom variable in the global window object
- the React code can access these values inside the window object
- the URLs will be set to those values, if the environment variable are defined, and to the values assigned at build time to $REACT_APP_SERVER_URL and $REACT_APP_REPOSITORY_SERVER_URL (respectively) otherwise.

**Related issue(s)**:

Fixes #20

**Notes for reviewer**:

This is code is already running in the POC server (pointed to by Hashscan staging).
