### PR TITLE
Remove linux/arm64 platform for the build of server and repository images

### DIFF
--- a/.github/workflows/release-image-to-github.yaml
+++ b/.github/workflows/release-image-to-github.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           context: .
           file: ./src/Dockerfile.server
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:server-${{env.TAG}}
 
@@ -68,6 +68,6 @@ jobs:
         with:
           context: ./h5ai-nginx
           file: ./h5ai-nginx/Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:repository-${{env.TAG}}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           context: .
           file: ./src/Dockerfile.server
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:server-${{env.TAG}}
 
@@ -79,6 +79,6 @@ jobs:
         with:
           context: ./h5ai-nginx
           file: ./h5ai-nginx/Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:repository-${{env.TAG}}


### PR DESCRIPTION
**Description**:

Build of `server` image hangs when targeting platform `linux/arm64` so we remove it (as well as for the `repository`, which is always co-located with server).
