### PR TITLE
Deploying from this chart code would catch a failure on the dash in r…

### DIFF
--- a/charts/templates/server-repository/deployment.yaml
+++ b/charts/templates/server-repository/deployment.yaml
@@ -68,9 +68,9 @@ spec:
               mountPath: /data
         - name: {{ printf "%s-%s" .Chart.Name "repository" }}
           securityContext:
-            {{- toYaml .Values.repository.securityContext | nindent 12 }}
+            {{- toYaml .Values.serverRepository.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.serverRepository.image.repository.tag | default "repository-latest" }}"
-          imagePullPolicy: {{ .Values.repository.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.serverRepository.image.pullPolicy }}
           envFrom:
             - configMapRef:
                 name: {{ template "sourcify.name" . }}          

--- a/charts/templates/server-repository/reset-job.yaml
+++ b/charts/templates/server-repository/reset-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.reset.previewnet-reset.enabled }}
+{{- if .Values.reset.previewnet_reset.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,7 +18,7 @@ spec:
         - https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh previewnet
 {{- end }}
 ---
-{{- if .Values.reset.testnet-reset.enabled }}
+{{- if .Values.reset.testnet_reset.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -152,10 +152,10 @@ ui:
 
 reset:
   ## Previewnet reset job, default is to disable
-  previewnet-reset: 
+  previewnet_reset: 
     enabled: false
   ## Testnet reset job, default is to disable
-  testnet-reset:
+  testnet_reset:
     enabled: false  
   ## Set default immage repository, tag, and pull policy
   image:


### PR DESCRIPTION
**Description**:
This PR fixes the incorrect `-` and changes it to `_`; also corrects the `nil pointer` because the deployment spec was pointing to an incorrect value location.

**Checklist**

- [x] Documented (values.yaml)
- [x] Tested - deployed to test env
