### PR TITLE
feat: add dry run parameter to /session/input-files and /session/verify-checked end-points

### DIFF
--- a/src/server/controllers/verification/session-state/input-files.session-state.paths.yaml
+++ b/src/server/controllers/verification/session-state/input-files.session-state.paths.yaml
@@ -42,7 +42,8 @@ paths:
           in: query
           schema:
             type: boolean
-          description: Dry-run flag. When set to true, a successful verification result will not be stored in the repository.
+            default: false
+          description: Dry-run flag. When present and set to true, a successful verification result will not be stored in the repository.
           required: false
       responses:
         "200":

--- a/src/server/controllers/verification/session-state/input-files.session-state.paths.yaml
+++ b/src/server/controllers/verification/session-state/input-files.session-state.paths.yaml
@@ -1,5 +1,4 @@
 openapi: "3.0.0"
-
 paths:
   /session/input-files:
     post:
@@ -38,6 +37,12 @@ paths:
             type: string
             format: uri
           description: Remote file URL
+          required: false
+        - name: dryrun
+          in: query
+          schema:
+            type: boolean
+          description: Dry-run flag. When set to true, a successful verification result will not be stored in the repository.
           required: false
       responses:
         "200":

--- a/src/server/controllers/verification/session-state/session-state.handlers.ts
+++ b/src/server/controllers/verification/session-state/session-state.handlers.ts
@@ -40,6 +40,7 @@ export async function addInputFilesEndpoint(req: Request, res: Response) {
     return { path: pb.path, content: pb.buffer.toString(FILE_ENCODING) };
   });
 
+  const dryRun = Boolean(req.body.dryRun)
   const session = req.session;
   const newFilesCount = saveFiles(pathContents, session);
   if (newFilesCount) {
@@ -48,7 +49,8 @@ export async function addInputFilesEndpoint(req: Request, res: Response) {
       session.contractWrappers,
       session,
       services.verification,
-      services.repository
+      services.repository,
+      dryRun
     );
   }
   res.send(getSessionJSON(session));
@@ -102,6 +104,7 @@ export async function addInputContractEndpoint(req: Request, res: Response) {
     content: retrievedMetadataBase64,
   });
 
+  const dryRun = Boolean(req.query.dryrun)
   const session = req.session;
 
   const newFilesCount = saveFiles(pathContents, session);
@@ -112,7 +115,8 @@ export async function addInputContractEndpoint(req: Request, res: Response) {
       session.contractWrappers,
       session,
       services.verification,
-      services.repository
+      services.repository,
+      dryRun
     );
   }
   res.send(getSessionJSON(session));

--- a/src/server/controllers/verification/session-state/session-state.handlers.ts
+++ b/src/server/controllers/verification/session-state/session-state.handlers.ts
@@ -40,7 +40,7 @@ export async function addInputFilesEndpoint(req: Request, res: Response) {
     return { path: pb.path, content: pb.buffer.toString(FILE_ENCODING) };
   });
 
-  const dryRun = Boolean(req.body.dryRun)
+  const dryRun = Boolean(req.query.dryrun)
   const session = req.session;
   const newFilesCount = saveFiles(pathContents, session);
   if (newFilesCount) {

--- a/src/server/controllers/verification/session-state/session-state.handlers.ts
+++ b/src/server/controllers/verification/session-state/session-state.handlers.ts
@@ -40,6 +40,7 @@ export async function addInputFilesEndpoint(req: Request, res: Response) {
     return { path: pb.path, content: pb.buffer.toString(FILE_ENCODING) };
   });
 
+  // when undefined, the dryrun parameter interpreted as false
   const dryRun = Boolean(req.query.dryrun)
   const session = req.session;
   const newFilesCount = saveFiles(pathContents, session);
@@ -104,6 +105,7 @@ export async function addInputContractEndpoint(req: Request, res: Response) {
     content: retrievedMetadataBase64,
   });
 
+  // when undefined, the dryrun parameter interpreted as false
   const dryRun = Boolean(req.query.dryrun)
   const session = req.session;
 

--- a/src/server/controllers/verification/verification.common.ts
+++ b/src/server/controllers/verification/verification.common.ts
@@ -294,7 +294,8 @@ export const verifyContractsInSession = async (
   contractWrappers: ContractWrapperMap,
   session: Session,
   verificationService: IVerificationService,
-  repositoryService: IRepositoryService
+  repositoryService: IRepositoryService,
+  dryRun: boolean = false
 ): Promise<void> => {
   for (const id in contractWrappers) {
     const contractWrapper = contractWrappers[id];
@@ -379,7 +380,7 @@ export const verifyContractsInSession = async (
     contractWrapper.status = match.status || "error";
     contractWrapper.statusMessage = match.message;
     contractWrapper.storageTimestamp = match.storageTimestamp;
-    if (match.status) {
+    if (match.status && !dryRun) {
       await repositoryService.storeMatch(checkedContract, match);
     }
   }

--- a/src/server/controllers/verification/verify/session/verify.session.handlers.ts
+++ b/src/server/controllers/verification/verify/session/verify.session.handlers.ts
@@ -19,6 +19,7 @@ export async function verifyContractsInSessionEndpoint(
     throw new BadRequestError("There are currently no pending contracts.");
   }
 
+  const dryRun = Boolean(req.query.dryRun)
   const receivedContracts: SendableContract[] = req.body.contracts;
 
   const verifiable: ContractWrapperMap = {};
@@ -40,7 +41,8 @@ export async function verifyContractsInSessionEndpoint(
     verifiable,
     session,
     services.verification,
-    services.repository
+    services.repository,
+    dryRun
   );
   res.send(getSessionJSON(session));
 }

--- a/src/server/controllers/verification/verify/session/verify.session.paths.yaml
+++ b/src/server/controllers/verification/verify/session/verify.session.paths.yaml
@@ -31,6 +31,13 @@ paths:
                       verificationId:
                         type: string
                         example: "0x3f67e9f57515bb1e7195c7c5af1eff630091567c0bb65ba3dece57a56da766fe"
+      parameters:
+        - name: dryrun
+          in: query
+          schema:
+            type: boolean
+          description: Dry-run flag. When set to true, a successful verification result will not be stored in the repository.
+          required: false
       responses:
         "200":
           description: OK

--- a/src/server/controllers/verification/verify/session/verify.session.paths.yaml
+++ b/src/server/controllers/verification/verify/session/verify.session.paths.yaml
@@ -36,7 +36,8 @@ paths:
           in: query
           schema:
             type: boolean
-          description: Dry-run flag. When set to true, a successful verification result will not be stored in the repository.
+            default: false
+          description: Dry-run flag. When present and set to true, a successful verification result will not be stored in the repository.
           required: false
       responses:
         "200":


### PR DESCRIPTION
**Description**:

Add optional `dryrun` query parameter to the 2 endpoints of the session API (`/session/input-files` and `/session/verify-checked`) used by mirror-node explorer.
When the parameter is present and set to true, the result of the (successful) verification is not stored in the repository.

**Related issue(s)**:

Fixes #90

