### PR TITLE
fix: repository lookup select contract form

### DIFF
--- a/hedera-patch/h5ai-nginx.patch
+++ b/hedera-patch/h5ai-nginx.patch
@@ -1,5 +1,65 @@
 Subject: [PATCH] h5ai-nginx
 ---
+Index: h5ai.patch
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/h5ai.patch b/h5ai.patch
+new file mode 100644
+--- /dev/null	(date 1702401995981)
++++ b/h5ai.patch	(date 1702401995981)
+@@ -0,0 +1,32 @@
++Subject: [PATCH] suppress link to remix
++---
++Index: src/_h5ai/public/js/lib/view/view.js
++IDEA additional info:
++Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
++<+>UTF-8
++===================================================================
++diff --git a/src/_h5ai/public/js/lib/view/view.js b/src/_h5ai/public/js/lib/view/view.js
++--- a/src/_h5ai/public/js/lib/view/view.js	(revision 15173ca22fcd4e9b2c0d11bdacc509428dba1bcd)
+++++ b/src/_h5ai/public/js/lib/view/view.js	(date 1699289694771)
++@@ -32,9 +32,6 @@
++                 </li>
++             </ul>
++             <div id="view-hint"></div>
++-            <div style="margin-top: 2rem; text-decoration: underline;">
++-                <a id="open_in_remix" href="#" target="_blank" rel="noopener noreferrer">Open repo in Remix</a>
++-            </div>
++         </div>`;
++ const itemTpl =
++         `<li class="item">
++@@ -49,11 +46,9 @@
++ const $view = dom(viewTpl);
++ const $items = $view.find('#items');
++ const $hint = $view.find('#view-hint');
++-const $remix_link = $view.find('#open_in_remix');
++ const $path = global.window.location.href.split('/');
++ const $address = $path[6];
++ const $chainId = $path[5];
++-$remix_link.attr('href', `https://remix.ethereum.org/?#activate=sourcify&call=sourcify//fetchAndSave//${$address}//${$chainId}`);
++
++
++ const cropSize = (size, min, max) => Math.min(max, Math.max(min, size));
+Index: Dockerfile
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/Dockerfile b/Dockerfile
+--- a/Dockerfile	(revision 453a6681ef93a7a43ee339b5301743e27d7a3b62)
++++ b/Dockerfile	(date 1702401995981)
+@@ -1,6 +1,9 @@
+ FROM node:14-alpine
+ RUN apk add --no-cache git
+ RUN git clone https://github.com/sourcifyeth/h5ai.git
++RUN cd h5ai && git checkout 15173ca22fcd4e9b2c0d11bdacc509428dba1bcd
++COPY h5ai.patch /h5ai.patch
++RUN cd h5ai && git apply /h5ai.patch
+ RUN cd h5ai && npm install && npm run build 
+ RUN mv $(ls -1 /h5ai/build/*.zip) /h5ai/build/h5ai.zip
+ RUN ls /h5ai/build/
 Index: select-contract-form/src/App.js
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
@@ -7,16 +67,17 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/select-contract-form/src/App.js b/select-contract-form/src/App.js
 --- a/select-contract-form/src/App.js	(revision 453a6681ef93a7a43ee339b5301743e27d7a3b62)
-+++ b/select-contract-form/src/App.js	(date 1699367507735)
-@@ -2,6 +2,7 @@
++++ b/select-contract-form/src/App.js	(date 1702402333663)
+@@ -2,6 +2,8 @@
  import { useEffect, useRef, useState } from "react";
  import { Alert, Button, Card, Form, Spinner } from "react-bootstrap";
  import "./App.scss";
 +import axios from "axios";
++import { getAddress } from "@ethersproject/address";
  
  function App() {
    const [selectedMatch, setSelectedMatch] = useState("full_match");
-@@ -20,17 +21,33 @@
+@@ -20,17 +22,33 @@
    ];
  
    useEffect(() => {
@@ -57,66 +118,16 @@ diff --git a/select-contract-form/src/App.js b/select-contract-form/src/App.js
        .catch((err) => alert(err));
    }, []);
  
-Index: Dockerfile
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/Dockerfile b/Dockerfile
---- a/Dockerfile	(revision 453a6681ef93a7a43ee339b5301743e27d7a3b62)
-+++ b/Dockerfile	(date 1699367072922)
-@@ -1,6 +1,9 @@
- FROM node:14-alpine
- RUN apk add --no-cache git
- RUN git clone https://github.com/sourcifyeth/h5ai.git
-+RUN cd h5ai && git checkout 15173ca22fcd4e9b2c0d11bdacc509428dba1bcd
-+COPY h5ai.patch /h5ai.patch
-+RUN cd h5ai && git apply /h5ai.patch
- RUN cd h5ai && npm install && npm run build 
- RUN mv $(ls -1 /h5ai/build/*.zip) /h5ai/build/h5ai.zip
- RUN ls /h5ai/build/
-Index: h5ai.patch
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/h5ai.patch b/h5ai.patch
-new file mode 100644
---- /dev/null	(date 1699293561021)
-+++ b/h5ai.patch	(date 1699293561021)
-@@ -0,0 +1,32 @@
-+Subject: [PATCH] suppress link to remix
-+---
-+Index: src/_h5ai/public/js/lib/view/view.js
-+IDEA additional info:
-+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-+<+>UTF-8
-+===================================================================
-+diff --git a/src/_h5ai/public/js/lib/view/view.js b/src/_h5ai/public/js/lib/view/view.js
-+--- a/src/_h5ai/public/js/lib/view/view.js	(revision 15173ca22fcd4e9b2c0d11bdacc509428dba1bcd)
-++++ b/src/_h5ai/public/js/lib/view/view.js	(date 1699289694771)
-+@@ -32,9 +32,6 @@
-+                 </li>
-+             </ul>
-+             <div id="view-hint"></div>
-+-            <div style="margin-top: 2rem; text-decoration: underline;">
-+-                <a id="open_in_remix" href="#" target="_blank" rel="noopener noreferrer">Open repo in Remix</a>
-+-            </div>
-+         </div>`;
-+ const itemTpl =
-+         `<li class="item">
-+@@ -49,11 +46,9 @@
-+ const $view = dom(viewTpl);
-+ const $items = $view.find('#items');
-+ const $hint = $view.find('#view-hint');
-+-const $remix_link = $view.find('#open_in_remix');
-+ const $path = global.window.location.href.split('/');
-+ const $address = $path[6];
-+ const $chainId = $path[5];
-+-$remix_link.attr('href', `https://remix.ethereum.org/?#activate=sourcify&call=sourcify//fetchAndSave//${$address}//${$chainId}`);
-+
-+
-+ const cropSize = (size, min, max) => Math.min(max, Math.max(min, size));
+@@ -48,7 +66,8 @@
+       return;
+     }
+ 
+-    const uri = generateRepoURI(address, chainId, selectedMatch);
++    const checksummedAddress = getAddress(address);
++    const uri = generateRepoURI(checksummedAddress, chainId, selectedMatch);
+     // Look ahead if contract exists.
+     setIsLoading(true);
+     fetch(uri, { redirect: "follow" })
 Index: select-contract-form/package.json
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
@@ -124,15 +135,17 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/select-contract-form/package.json b/select-contract-form/package.json
 --- a/select-contract-form/package.json	(revision 453a6681ef93a7a43ee339b5301743e27d7a3b62)
-+++ b/select-contract-form/package.json	(date 1699359289868)
-@@ -6,6 +6,7 @@
++++ b/select-contract-form/package.json	(date 1702402266251)
+@@ -6,7 +6,9 @@
      "@testing-library/jest-dom": "^5.11.4",
      "@testing-library/react": "^11.1.0",
      "@testing-library/user-event": "^12.1.10",
 +    "axios": "^1.5.0",
      "bootstrap": "^5.1.1",
++    "@ethersproject/address": "^5.6.1",
      "node-sass": "^4.14.1",
      "react": "^17.0.2",
+     "react-bootstrap": "^2.0.0-rc.0",
 Index: select-contract-form/public/config.json
 IDEA additional info:
 Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
@@ -140,8 +153,8 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/select-contract-form/public/config.json b/select-contract-form/public/config.json
 new file mode 100644
---- /dev/null	(date 1699359289869)
-+++ b/select-contract-form/public/config.json	(date 1699359289869)
+--- /dev/null	(date 1702401995981)
++++ b/select-contract-form/public/config.json	(date 1702401995981)
 @@ -0,0 +1,3 @@
 +  {
 +    "SERVER_URL": "http://localhost:5002"


### PR DESCRIPTION
**Description**:

Use checksummed address lookup in the repository `select-contract-form`. This allows the user to use the form with non-checksummed addresses.

**Related issue(s)**:

Fixes #91 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
