### PR TITLE
Update reset jobs making them recreatable

### DIFF
--- a/charts/templates/server-repository/reset-job.yaml
+++ b/charts/templates/server-repository/reset-job.yaml
@@ -1,39 +1,52 @@
 {{- if .Values.reset.previewnet_reset.enabled }}
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: {{ printf "%s-%s" .Chart.Name "prvw-reset-job" | trimSuffix "-"| trunc 52 }}
 spec:
-  # activeDeadlineSeconds: 600 ## this is used to termanate the job after 10 minutes.  How long does it take to reset and shoud this be set?
-  # backoffLimit: 0 # Number of failed retries before considering a Job as failed. Defaults to 6 if not set.  Should this be set to 0?  How many failures are acceptable?
-  template:
+  concurrencyPolicy: Forbid
+  # This is purposely set to a date known to never exist.  This should only be run via manual trigger, never by time based trigger
+  schedule: "0 0 31 2 *"
+  jobTemplate:
     spec:
-      containers:
-      - name: reset
-        image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
-        imagePullPolicy: {{ .Values.reset.image.pullPolicy }}
-        command:
-        - /bin/sh
-        - -c
-        - https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh previewnet
+      backoffLimit: 0
+      template:
+        spec:
+          serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
+          restartPolicy: Never
+          containers:
+          - name: reset
+            image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
+            imagePullPolicy: {{ .Values.reset.image.pullPolicy }}
+            command:
+            - /bin/sh
+            - -c
+            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh previewnet
 {{- end }}
+
 ---
 {{- if .Values.reset.testnet_reset.enabled }}
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-job" | trimSuffix "-"| trunc 52 }}
 spec:
-  # activeDeadlineSeconds: 600 ## this is used to termanate the job after 10 minutes.  How long does it take to reset and shoud this be set?
-  # backoffLimit: 0 # Number of failed retries before considering a Job as failed. Defaults to 6 if not set.  Should this be set to 0?  How many failures are acceptable?
-  template:
+  concurrencyPolicy: Forbid
+  # This is purposely set to a date known to never exist.  This should only be run via manual trigger, never by time based trigger
+  schedule: "0 0 31 2 *"
+  jobTemplate:
     spec:
-      containers:
-      - name: reset
-        image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
-        imagePullPolicy: {{ .Values.reset.image.pullPolicy }}
-        command:
-        - /bin/sh
-        - -c
-        - https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh testnet
+      backoffLimit: 0
+      template:
+        spec:
+          serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
+          restartPolicy: Never
+          containers:
+          - name: reset
+            image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
+            imagePullPolicy: {{ .Values.reset.image.pullPolicy }}
+            command:
+            - /bin/sh
+            - -c
+            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh testnet
 {{- end }}


### PR DESCRIPTION
**Description**:
This PR updates the reset jobs to use `cronjobs` instead of `jobs`.  It also changes to using `wget` from `curl`; prior to the wget change curl would simply pull the script to stdout but was not saved anywhere .  This change fixes that to get the file correct.

**Notes for reviewer**:
This change has been deployed into the test env
