### PR TITLE
Ignore patched changes in submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "h5ai-nginx"]
 	path = h5ai-nginx
 	url = https://github.com/sourcifyeth/h5ai-nginx
+	ignore = dirty


### PR DESCRIPTION
**Description**:

This PR ignores changes in the `h5ai-nginx` submodule **after** applying our customization patch `hedera-patch/h5ai-nginx.patch`. It does so by setting [`ignore = dirty`](https://git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-dirty) in the submodule.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

- Fixes #105 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
