### PR TITLE
ci: enable `contract-call-decoder` unit tests in CI by skipping IPFS test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,18 @@ jobs:
       - run: npx lerna bootstrap && npx lerna run build
       - run: cd packages/bytecode-utils && npm run test
 
+  contract-call-decoder-uts:
+    name: contract-call-decoder unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npx lerna bootstrap && npx lerna run build
+      - run: cd packages/contract-call-decoder && npm run test
+
   lib-sourcify-uts:
     name: lib-sourcify unit tests
     runs-on: ubuntu-latest

--- a/packages/contract-call-decoder/src/lib/ContractCallDecoder.spec.ts
+++ b/packages/contract-call-decoder/src/lib/ContractCallDecoder.spec.ts
@@ -124,7 +124,7 @@ test('evaluate calldata can correctly parse addresses, bigints and bytes', async
   t.is(`${decodedContractCall.method.decodedParams[3]}`, '0x010101ff');
 });
 
-test('evaluate calldata from tx getting metadata from bytecode', async (t) => {
+test.skip('evaluate calldata from tx getting metadata from bytecode', async (t) => {
   const ethereumProvider = provider('https://rpc.ankr.com/eth_goerli');
   const tx = {
     to: '0xD4B081C226Bc8aBdaf111DEf54c09E779ad29428',


### PR DESCRIPTION
**Description**:

Enable `contract-call-decoder` unit tests in CI by skipping failing IPFS test.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
