### PR TITLE
fix: typo in dryrun query parameter.

### DIFF
--- a/src/server/controllers/verification/verify/session/verify.session.handlers.ts
+++ b/src/server/controllers/verification/verify/session/verify.session.handlers.ts
@@ -19,7 +19,7 @@ export async function verifyContractsInSessionEndpoint(
     throw new BadRequestError("There are currently no pending contracts.");
   }
 
-  const dryRun = Boolean(req.query.dryRun)
+  const dryRun = Boolean(req.query.dryrun)
   const receivedContracts: SendableContract[] = req.body.contracts;
 
   const verifiable: ContractWrapperMap = {};


### PR DESCRIPTION
**Description**:

Fix typo in query parameter expected by `/session/verify-checked endpoint`. The endpoint was expecting `dryRun` instead of `dryrun`. This does not reveal in the deployed code where the behaviour is case insensitive, but it reveals in the server testing environment.

**Related issue(s)**:

Fixes #110 

**Notes for reviewer**:

This issue blocks PR for issue #93 which adds tests covering the use of this query parameter.
