### PR TITLE
fix: remove session endpoints and fix server drop-down

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,7 +15,7 @@ servers:
     url: "http://localhost:5002"
 tags:
   - name: Session Verification
-    description: Not supported endpoints. Use with caution.
+    description: Endpoints behind CORS validation. Unable to use them from outside the domain `hashscan.io`.
 paths:
   /session/data:
     $ref: "src/server/controllers/verification/session-state/data.session-state.paths.yaml#/paths/~1session~1data"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,29 +11,30 @@ servers:
     url: ""
   - description: The production REST API server
     url: "https://server-verify.hashscan.io"
-  - description: The integration REST API server
-    url: "https://server-sourcify.hedera-devops.com"
   - description: Local development server address on default port 5002
     url: "http://localhost:5002"
+tags:
+  - name: Session Verification
+    description: Not supported endpoints. Use with caution.
 paths:
-  # /session/data:
-  #   $ref: "src/server/controllers/verification/session-state/data.session-state.paths.yaml#/paths/~1session~1data"
-  # /session/clear:
-  #   $ref: "src/server/controllers/verification/session-state/clear.session-state.paths.yaml#/paths/~1session~1clear"
-  # /session/input-files:
-  #   $ref: "src/server/controllers/verification/session-state/input-files.session-state.paths.yaml#/paths/~1session~1input-files"
-  # /session/input-contract:
-  #   $ref: "src/server/controllers/verification/session-state/input-contract.session-state.paths.yaml#/paths/~1session~1input-contract"
-  # /session/verify-checked:
-  #   $ref: "src/server/controllers/verification/verify/session/verify.session.paths.yaml#/paths/~1session~1verify-checked"
-  # /session/input-solc-json:
-  #   $ref: "src/server/controllers/verification/solc-json/session/solc-json.session.paths.yaml#/paths/~1session~1input-solc-json"
-  # /session/verify/create2:
-  #   $ref: "src/server/controllers/verification/create2/session/create2.session.paths.yaml#/paths/~1session~1verify~1create2"
-  # /session/verify/create2/compile:
-  #   $ref: "src/server/controllers/verification/create2/session/compile.create2.session.paths.yaml#/paths/~1session~1verify~1create2~1compile"
-  # /session/verify/etherscan:
-  #   $ref: "src/server/controllers/verification/etherscan/session/etherscan.session.paths.yaml#/paths/~1session~1verify~1etherscan"
+  /session/data:
+    $ref: "src/server/controllers/verification/session-state/data.session-state.paths.yaml#/paths/~1session~1data"
+  /session/clear:
+    $ref: "src/server/controllers/verification/session-state/clear.session-state.paths.yaml#/paths/~1session~1clear"
+  /session/input-files:
+    $ref: "src/server/controllers/verification/session-state/input-files.session-state.paths.yaml#/paths/~1session~1input-files"
+  /session/input-contract:
+    $ref: "src/server/controllers/verification/session-state/input-contract.session-state.paths.yaml#/paths/~1session~1input-contract"
+  /session/verify-checked:
+    $ref: "src/server/controllers/verification/verify/session/verify.session.paths.yaml#/paths/~1session~1verify-checked"
+  /session/input-solc-json:
+    $ref: "src/server/controllers/verification/solc-json/session/solc-json.session.paths.yaml#/paths/~1session~1input-solc-json"
+  /session/verify/create2:
+    $ref: "src/server/controllers/verification/create2/session/create2.session.paths.yaml#/paths/~1session~1verify~1create2"
+  /session/verify/create2/compile:
+    $ref: "src/server/controllers/verification/create2/session/compile.create2.session.paths.yaml#/paths/~1session~1verify~1create2~1compile"
+  /session/verify/etherscan:
+    $ref: "src/server/controllers/verification/etherscan/session/etherscan.session.paths.yaml#/paths/~1session~1verify~1etherscan"
   /verify:
     $ref: "src/server/controllers/verification/verify/stateless/verify.stateless.paths.yaml#/paths/~1verify"
   /verify/solc-json:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,35 +7,41 @@ info:
     name: MIT
     url: https://github.com/hashgraph/hedera-sourcify/blob/master/LICENSE
 servers:
-  - url: http://localhost:5002
-    description: Local development server address on default port 5002.
+  - description: The current REST API server
+    url: ""
+  - description: The production REST API server
+    url: "https://server-verify.hashscan.io"
+  - description: The integration REST API server
+    url: "https://server-sourcify.hedera-devops.com"
+  - description: Local development server address on default port 5002
+    url: "http://localhost:5002"
 paths:
-  /session/data:
-    $ref: "src/server/controllers/verification/session-state/data.session-state.paths.yaml#/paths/~1session~1data"
-  /session/clear:
-    $ref: "src/server/controllers/verification/session-state/clear.session-state.paths.yaml#/paths/~1session~1clear"
-  /session/input-files:
-    $ref: "src/server/controllers/verification/session-state/input-files.session-state.paths.yaml#/paths/~1session~1input-files"
-  /session/input-contract:
-    $ref: "src/server/controllers/verification/session-state/input-contract.session-state.paths.yaml#/paths/~1session~1input-contract"
+  # /session/data:
+  #   $ref: "src/server/controllers/verification/session-state/data.session-state.paths.yaml#/paths/~1session~1data"
+  # /session/clear:
+  #   $ref: "src/server/controllers/verification/session-state/clear.session-state.paths.yaml#/paths/~1session~1clear"
+  # /session/input-files:
+  #   $ref: "src/server/controllers/verification/session-state/input-files.session-state.paths.yaml#/paths/~1session~1input-files"
+  # /session/input-contract:
+  #   $ref: "src/server/controllers/verification/session-state/input-contract.session-state.paths.yaml#/paths/~1session~1input-contract"
+  # /session/verify-checked:
+  #   $ref: "src/server/controllers/verification/verify/session/verify.session.paths.yaml#/paths/~1session~1verify-checked"
+  # /session/input-solc-json:
+  #   $ref: "src/server/controllers/verification/solc-json/session/solc-json.session.paths.yaml#/paths/~1session~1input-solc-json"
+  # /session/verify/create2:
+  #   $ref: "src/server/controllers/verification/create2/session/create2.session.paths.yaml#/paths/~1session~1verify~1create2"
+  # /session/verify/create2/compile:
+  #   $ref: "src/server/controllers/verification/create2/session/compile.create2.session.paths.yaml#/paths/~1session~1verify~1create2~1compile"
+  # /session/verify/etherscan:
+  #   $ref: "src/server/controllers/verification/etherscan/session/etherscan.session.paths.yaml#/paths/~1session~1verify~1etherscan"
   /verify:
     $ref: "src/server/controllers/verification/verify/stateless/verify.stateless.paths.yaml#/paths/~1verify"
-  /session/verify-checked:
-    $ref: "src/server/controllers/verification/verify/session/verify.session.paths.yaml#/paths/~1session~1verify-checked"
   /verify/solc-json:
     $ref: "src/server/controllers/verification/solc-json/stateless/solc-json.stateless.paths.yaml#/paths/~1verify~1solc-json"
-  /session/input-solc-json:
-    $ref: "src/server/controllers/verification/solc-json/session/solc-json.session.paths.yaml#/paths/~1session~1input-solc-json"
   /verify/create2:
     $ref: "src/server/controllers/verification/create2/stateless/create2.stateless.paths.yaml#/paths/~1verify~1create2"
-  /session/verify/create2:
-    $ref: "src/server/controllers/verification/create2/session/create2.session.paths.yaml#/paths/~1session~1verify~1create2"
-  /session/verify/create2/compile:
-    $ref: "src/server/controllers/verification/create2/session/compile.create2.session.paths.yaml#/paths/~1session~1verify~1create2~1compile"
   /verify/etherscan:
     $ref: "src/server/controllers/verification/etherscan/stateless/etherscan.stateless.paths.yaml#/paths/~1verify~1etherscan"
-  /session/verify/etherscan:
-    $ref: "src/server/controllers/verification/etherscan/session/etherscan.session.paths.yaml#/paths/~1session~1verify~1etherscan"
   /check-all-by-addresses:
     $ref: "src/server/controllers/repository/check-all-by-addresses.stateless.paths.yaml#/paths/~1check-all-by-addresses"
   /check-by-addresses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,7 +15,7 @@ servers:
     url: "http://localhost:5002"
 tags:
   - name: Session Verification
-    description: Endpoints behind CORS validation. Unable to use them from outside the domain `hashscan.io`.
+    description: Endpoints behind CORS validation. Unable to use them from outside the deployed domain e.g `example.io`.
 paths:
   /session/data:
     $ref: "src/server/controllers/verification/session-state/data.session-state.paths.yaml#/paths/~1session~1data"


### PR DESCRIPTION
**Description**:

Remove session endpoints so that we can share the api-docs. Also fix the server drop-down which was showing always the local dev server.

I have included both prod and local server in the drop-down, but maybe the _Current REST API server_ suffices.

**Default server value**

<img width="601" alt="image" src="https://github.com/hashgraph/hedera-sourcify/assets/4592980/bbcb3d76-4836-467c-8fb1-7f85a41784e2">

**When the user opens the servers drop-down**

<img width="612" alt="image" src="https://github.com/hashgraph/hedera-sourcify/assets/4592980/7aa7c19e-99b6-4ade-946c-bde9c6ff514d">

**Session endpoints label**

<img width="758" alt="image" src="https://github.com/hashgraph/hedera-sourcify/assets/4592980/0d2db073-f6c9-4612-a416-bd21e51371db">

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
