### PR TITLE
feat: Use version 2.6.1 where the cosign issue is expected to be fixed

### DIFF
--- a/.github/workflows/chart-lint-test.yaml
+++ b/.github/workflows/chart-lint-test.yaml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.x'
 
     - name: Install chart-testing
-      uses: helm/chart-testing-action@v2.4.0
+      uses: helm/chart-testing-action@v2.6.1
       
     - name: Run chart-testing (list-changed)
       id: list-changed


### PR DESCRIPTION
**Description**:
This PR modifies ... in order to support ...
* Updates the `chart-testing-action` version from `2.4.0` to `2.6.1`


**Related issue(s)**:

Fixes #128 

**Notes for reviewer**:
Not sure how to test this outside of rebasing a failing PR with this branch (is there a better way though to test GH action changes?)

