### PR TITLE
chore: change CONTRACT_PATH in reset script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,20 +171,21 @@ The following properties can be provided in config.json
 
 The following environment variables are needed by the _server_ at runtime:
 
-| Name                          | Example value                   | Description                                                                             |
-|-------------------------------|---------------------------------|-----------------------------------------------------------------------------------------|
-| `REPOSITORY_PATH`             | ../../data/repository           | DO NOT CHANGE - Path of the contract repository, both inside container and on the host. |
-| `SOLC_REPO`                   | /home/data/solc-bin/linux-amd64 | Path where Solidity compiler binaries will be saved (inside container)                  |
-| `SOLJSON_REPO`                | /home/data/solc-bin/soljson     | Path where Solidity JS compilers will be saved (inside container)                       |
-| `SOLC_REPO_HOST`              | ../../data/solc-bin/linux-amd64 | Path for the Solidity compiler binaries downloaded (on host machine)                    |
-| `SOLJSON_REPO_HOST`           | ../../data/solc-bin/soljson     | Path for the Solidity JS compilers downloaded (on host machine)                         |
-| `SERVER_PORT`                 | 80                              | HTTP port used inside container                                                         |
-| `SERVER_EXTERNAL_PORT`        | 5002                            | HTTP port exposed by container                                                          |
-| `UI_DOMAIN_NAME`              | example.com                     | Fully qualified domain name of the host running the ui                                  |
-| `SERVER_CREATE2_VERIFICATION` | false                           | Flag to activate server API endpoints related to create2 {true, false}                  |
-| `REPOSITORY_SERVER_URL`       | repository.example.com          | URL of repository server (from outside the cluster)                                     |
-| `TESTING`                     | false                           | DO NOT CHANGE                                                                           |
-| `TAG`                         | latest                          | Added to the docker image tags (e.g. ui-latest, server-latest, repository-latest)       |
+| Name                          | Example value                   | Description                                                                       |
+|-------------------------------|---------------------------------|-----------------------------------------------------------------------------------|
+| `REPOSITORY_PATH`             | /data                           | Path of the mount point of the verified contract repository (inside container)    |
+| `REPOSITORY_PATH_HOST`        | ../../data/repository           | Path of the verified contract repository (on host machine)                        |
+| `SOLC_REPO`                   | /home/data/solc-bin/linux-amd64 | Path where Solidity compiler binaries will be saved (inside container)            |
+| `SOLJSON_REPO`                | /home/data/solc-bin/soljson     | Path where Solidity JS compilers will be saved (inside container)                 |
+| `SOLC_REPO_HOST`              | ../../data/solc-bin/linux-amd64 | Path for the Solidity compiler binaries downloaded (on host machine)              |
+| `SOLJSON_REPO_HOST`           | ../../data/solc-bin/soljson     | Path for the Solidity JS compilers downloaded (on host machine)                   |
+| `SERVER_PORT`                 | 80                              | HTTP port used inside container                                                   |
+| `SERVER_EXTERNAL_PORT`        | 5002                            | HTTP port exposed by container                                                    |
+| `UI_DOMAIN_NAME`              | example.com                     | Fully qualified domain name of the host running the ui                            |
+| `SERVER_CREATE2_VERIFICATION` | false                           | Flag to activate server API endpoints related to create2 {true, false}            |
+| `REPOSITORY_SERVER_URL`       | repository.example.com          | URL of repository server (from outside the cluster)                               |
+| `TESTING`                     | false                           | DO NOT CHANGE                                                                     |
+| `TAG`                         | latest                          | Added to the docker image tags (e.g. ui-latest, server-latest, repository-latest) |
 
 ### _repository_ module
 

--- a/environments/.env.dev
+++ b/environments/.env.dev
@@ -38,9 +38,12 @@ WEB3_STORAGE_PINNING_SECRET=xxx
 NPM_TOKEN=xxx
 
 # Docker config
+## Relevant if your're running in a container
 ## Where to mount the downloaded compilers directory on the host machine
 SOLC_REPO_HOST=/home/gather/staging/data/solc-bin/linux-amd64
 SOLJSON_REPO_HOST=/home/gather/staging/data/solc-bin/bin
+# Repository path in the host machine
+REPOSITORY_PATH_HOST=/home/sourcify/production/data/repository
 ## Ports to access containers from the host
 SERVER_EXTERNAL_PORT=5555
 UI_EXTERNAL_PORT=1234

--- a/environments/.env.docker.hedera
+++ b/environments/.env.docker.hedera
@@ -5,14 +5,12 @@
 ###
 
 # Server config
-## Path where verified contracts will be saved
-## WARNING: DO NOT CHANGE THIS VALUE. It is currently used both as mount point
-## and as the path inside server container
-REPOSITORY_PATH=../../data/repository
+## Path where verified contracts will be saved (inside container)
+REPOSITORY_PATH=/data
 ## Path where Solidity compiler binaries will be saved (inside container)
-SOLC_REPO=/home/data/solc-bin/linux-amd64
+SOLC_REPO=/data/solc-bin/linux-amd64
 ## Path where Solidity JS (solc-js) compilers will be saved (inside container)
-SOLJSON_REPO=/home/data/solc-bin/soljson
+SOLJSON_REPO=/data/solc-bin/soljson
 ## Server port inside the docker container
 SERVER_PORT=80
 ## The fully qualified domain name of the host running the ui
@@ -33,6 +31,8 @@ SERVER_CREATE2_VERIFICATION=false
 REPOSITORY_SERVER_URL=http://localhost:10000
 
 # Docker config
+## Repository path on the host machine
+REPOSITORY_PATH_HOST=../../data/repository
 ## Where to mount the downloaded compilers directory on the host machine
 SOLC_REPO_HOST=../../data/solc-bin/linux-amd64
 SOLJSON_REPO_HOST=../../data/solc-bin/soljson

--- a/environments/.env.latest
+++ b/environments/.env.latest
@@ -3,8 +3,8 @@ SERVER_PORT=80
 SOLC_REPO=/home/data/solc-bin/linux-amd64
 SOLJSON_REPO=/home/data/solc-bin/soljson
 SESSION_SECRET=xxx
-IPFS_GATEWAY=http://ipfs-latest:8080/ipfs/
-REPOSITORY_PATH=../../data/repository
+IPFS_GATEWAY=xxx
+REPOSITORY_PATH=/home/data/repository
 
 # Repository web server config
 REPOSITORY_SERVER_PORT=80
@@ -13,6 +13,7 @@ REPOSITORY_SERVER_URL=https://repo.staging.sourcify.dev
 # Monitor config
 MONITOR_PORT=80
 MONITOR_FETCH_TIMEOUT=300000
+FALLBACK_IPFS_GATEWAY=xxx
 
 # S3 config
 AWS_S3_ACCESS_KEY_ID=xxx
@@ -39,9 +40,12 @@ WEB3_STORAGE_PINNING_SECRET=xxx
 NPM_TOKEN=xxx
 
 # Docker config
+## Relevant if your're running in a container
 ## Where to mount the downloaded compilers directory on the host machine
 SOLC_REPO_HOST=/home/gather/staging/data/solc-bin/linux-amd64
 SOLJSON_REPO_HOST=/home/gather/staging/data/solc-bin/bin
+# Repository path in the host machine
+REPOSITORY_PATH_HOST=/home/gather/staging/data/repository
 ## Ports to access containers from the host
 SERVER_EXTERNAL_PORT=5000
 UI_EXTERNAL_PORT=1234

--- a/environments/.env.stable
+++ b/environments/.env.stable
@@ -3,8 +3,8 @@ SERVER_PORT=80
 SOLC_REPO=/home/data/solc-bin/linux-amd64
 SOLJSON_REPO=/home/data/solc-bin/soljson
 SESSION_SECRET=xxx
-IPFS_GATEWAY=http://ipfs-stable:8080/ipfs/
-REPOSITORY_PATH=../../data/repository
+IPFS_GATEWAY=xxx
+REPOSITORY_PATH=/home/data/repository
 
 # Repository web server config
 REPOSITORY_SERVER_PORT=80
@@ -36,9 +36,12 @@ WEB3_STORAGE_PINNING_SECRET=xxx
 NPM_TOKEN=xxx
 
 # Docker config
+## Relevant if your're running in a container
 ## Where to mount the downloaded compilers directory on the host machine
 SOLC_REPO_HOST=/home/sourcify/production/data/solc-bin/linux-amd64
 SOLJSON_REPO_HOST=/home/sourcify/production/data/solc-bin/bin
+# Repository path in the host machine
+REPOSITORY_PATH_HOST=/home/sourcify/production/data/repository
 ## Ports to access containers from the host
 SERVER_EXTERNAL_PORT=5002
 UI_EXTERNAL_PORT=1235

--- a/environments/docker-compose-hedera.yaml
+++ b/environments/docker-compose-hedera.yaml
@@ -1,8 +1,4 @@
 version: "3.7"
-x-project-repository-mount: &project-repository-mount
-  type: bind
-  source: $REPOSITORY_PATH
-
 x-project-base: &project-base
   env_file:
     - .env
@@ -20,8 +16,9 @@ services:
     image: ghcr.io/hashgraph/hedera-sourcify:repository-${TAG}
     container_name: repository-${TAG}
     volumes:
-      - <<: *project-repository-mount
-        target: /data
+      - type: bind
+        source: $REPOSITORY_PATH_HOST
+        target: $REPOSITORY_PATH
         read_only: true
       - type: bind
         source: ./docker-config.json
@@ -36,8 +33,9 @@ services:
     ports:
       - "${SERVER_EXTERNAL_PORT}:${SERVER_PORT}"
     volumes:
-      - <<: *project-repository-mount
-        target: /home/data/repository
+      - type: bind
+        source: $REPOSITORY_PATH_HOST
+        target: $REPOSITORY_PATH
       - type: bind
         source: $SOLC_REPO_HOST
         target: $SOLC_REPO

--- a/environments/monitor.yaml
+++ b/environments/monitor.yaml
@@ -1,8 +1,4 @@
 version: "3.7"
-x-project-repository-mount:
-  &project-repository-mount
-  type: bind
-  source: $REPOSITORY_PATH
 
 x-project-base:
   &project-base
@@ -21,8 +17,9 @@ services:
     image: ethereum/source-verify:monitor-${TAG}
     container_name: monitor-${TAG}
     volumes:
-      - <<: *project-repository-mount
-        target: /home/data/repository
+      - type: bind
+        source: $REPOSITORY_PATH_HOST
+        target: $REPOSITORY_PATH
       - type: bind
         source: $SOLC_REPO_HOST
         target: $SOLC_REPO

--- a/environments/repository.yaml
+++ b/environments/repository.yaml
@@ -1,8 +1,4 @@
 version: "3.7"
-x-project-repository-mount: &project-repository-mount
-  type: bind
-  source: $REPOSITORY_PATH
-  read_only: true
 
 x-project-base: &project-base
   env_file:
@@ -23,8 +19,9 @@ services:
     image: ghcr.io/hashgraph/hedera-sourcify:repository-${TAG}
     container_name: repository-${TAG}
     volumes:
-      - <<: *project-repository-mount
-        target: /data
+      - type: bind
+        source: $REPOSITORY_PATH_HOST
+        target: $REPOSITORY_PATH
         read_only: true
       - type: bind
         source: ./docker-config.json

--- a/environments/s3.yaml
+++ b/environments/s3.yaml
@@ -1,7 +1,4 @@
 version: "3.7"
-x-project-repository-mount: &project-repository-mount
-  type: bind
-  source: $REPOSITORY_PATH
 
 x-project-base: &project-base
   env_file:
@@ -19,5 +16,6 @@ services:
     image: ethereum/source-verify:s3-${TAG}
     container_name: s3-${TAG}
     volumes:
-      - <<: *project-repository-mount
-        target: /app/repository/repository/
+      - type: bind
+        source: $REPOSITORY_PATH_HOST
+        target: $REPOSITORY_PATH

--- a/environments/server.yaml
+++ b/environments/server.yaml
@@ -1,7 +1,4 @@
 version: "3.7"
-x-project-repository-mount: &project-repository-mount
-  type: bind
-  source: $REPOSITORY_PATH
 
 x-project-base: &project-base
   env_file:
@@ -21,8 +18,9 @@ services:
     ports:
       - "${SERVER_EXTERNAL_PORT}:${SERVER_PORT}"
     volumes:
-      - <<: *project-repository-mount
-        target: /home/data/repository
+      - type: bind
+        source: $REPOSITORY_PATH_HOST
+        target: $REPOSITORY_PATH
       - type: bind
         source: $SOLC_REPO_HOST
         target: $SOLC_REPO

--- a/scripts/hedera-reset-docker.sh
+++ b/scripts/hedera-reset-docker.sh
@@ -16,7 +16,7 @@ case ${1} in
   *) echo "Usage: hedera-reset-docker.sh testnet | previewnet"; exit 22;;
 esac
 
-CONTRACT_PATH="/home/data/repository/contracts"
+CONTRACT_PATH="/data/contracts"
 
 if [ ! -d "${CONTRACT_PATH}" ]; then
   echo "Expected contract repository was not found at this path: ${CONTRACT_PATH}"


### PR DESCRIPTION
(cherry picked from commit 2f2d5626e7e1d7f3a0f08eae8bd81b19395edb45)

**Description**:

This PR cherry-picks a change made in the main branch, which fixes the CONTRACT_PATH in reset script to match the configuration used in production. This is in case a new network reset would take place while the release 0.2 is still in production. 
The other changes in this commit concern the development/docker configurations and should not be relevant to the production environment.