### PR TITLE
Reset mount filesystem

### DIFF
--- a/charts/templates/server-repository/reset-job.yaml
+++ b/charts/templates/server-repository/reset-job.yaml
@@ -13,7 +13,11 @@ spec:
       template:
         spec:
           serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
-          restartPolicy: Never        
+          restartPolicy: Never
+          # The node where this runs must be the same place the persistent volume is mounted.  The kubernetes pvc will show an annotation `volume.kubernetes.io/selected-node` with this value.
+          {{ if .Values.reset.previewnet_reset.nodeName }}
+          nodeName: {{ .Values.reset.previewnet_reset.nodeName }}
+          {{ end }}
           containers:
           - name: reset
             image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
@@ -21,7 +25,8 @@ spec:
             command:
             - /bin/sh
             - -c
-            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset-docker.sh ; chmod +x hedera-reset-docker.sh ; ./hedera-reset-docker.sh previewnet
+            # - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset-docker.sh ; chmod +x hedera-reset-docker.sh ; ./hedera-reset-docker.sh previewnet
+            - sleep 1000000
             volumeMounts:
               - name: {{ .Chart.Name }}
                 mountPath: /data              

--- a/charts/templates/server-repository/reset-job.yaml
+++ b/charts/templates/server-repository/reset-job.yaml
@@ -14,29 +14,63 @@ spec:
         spec:
           serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
           restartPolicy: Never
-          # The node where this runs must be the same place the persistent volume is mounted.  The kubernetes pvc will show an annotation `volume.kubernetes.io/selected-node` with this value.
-          {{ if .Values.reset.previewnet_reset.nodeName }}
-          nodeName: {{ .Values.reset.previewnet_reset.nodeName }}
-          {{ end }}
           containers:
           - name: reset
             image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
             imagePullPolicy: {{ .Values.reset.image.pullPolicy }}
             command:
-            - /bin/sh
+            - /bin/bash
             - -c
-            # - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset-docker.sh ; chmod +x hedera-reset-docker.sh ; ./hedera-reset-docker.sh previewnet
-            - sleep 1000000
-            volumeMounts:
-              - name: {{ .Chart.Name }}
-                mountPath: /data              
-          volumes:
-            - name: {{ .Chart.Name }}
-              persistentVolumeClaim:
-                claimName: {{ template "sourcify.name" . }}-pvc
+            - POD=$(kubectl get pods -l app.kubernetes.io/name=sourcify-server-repository -n sourcify | tail -1 | awk '{print $1}'); k exec -it -n sourcify $POD -- ./hedera-reset-docker.sh previewnet
+# This job requires a special service account with specific permissions to accomplish this task
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-%s" .Chart.Name "prvw-reset-sa" | trimSuffix "-"| trunc 52 }}
+  labels:
+    {{- include "sourcify.labels" . | nindent 4 }}
+  {{- with .Values.serverRepository.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-%s" .Chart.Name "prvw-reset-role" | trimSuffix "-"| trunc 52 }}
+  labels:
+    {{- include "sourcify.labels" . | nindent 4 }}
+  {{- with .Values.serverRepository.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-%s" .Chart.Name "prvw-reset-role-binding" | trimSuffix "-"| trunc 52 }}
+  labels:
+    {{- include "sourcify.labels" . | nindent 4 }}
+  {{- with .Values.serverRepository.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ printf "%s-%s" .Chart.Name "prvw-reset-role" | trimSuffix "-"| trunc 52 }}
+
 {{- end }}
 
----
+# Testnet reset job
 {{- if .Values.reset.testnet_reset.enabled }}
 apiVersion: batch/v1
 kind: CronJob
@@ -60,5 +94,51 @@ spec:
             command:
             - /bin/sh
             - -c
-            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset-docker.sh ; chmod +x hedera-reset-docker.sh ; ./hedera-reset-dcoker.sh testnet
+            - POD=$(kubectl get pods -l app.kubernetes.io/name=sourcify-server-repository -n sourcify | tail -1 | awk '{print $1}'); k exec -it -n sourcify $POD -- ./hedera-reset-docker.sh testnet
+
+# This job requires a special service account with specific permissions to accomplish this task
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-sa" | trimSuffix "-"| trunc 52 }}
+  labels:
+    {{- include "sourcify.labels" . | nindent 4 }}
+  {{- with .Values.serverRepository.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-role" | trimSuffix "-"| trunc 52 }}
+  labels:
+    {{- include "sourcify.labels" . | nindent 4 }}
+  {{- with .Values.serverRepository.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-role-binding" | trimSuffix "-"| trunc 52 }}
+  labels:
+    {{- include "sourcify.labels" . | nindent 4 }}
+  {{- with .Values.serverRepository.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-role" | trimSuffix "-"| trunc 52 }}
 {{- end }}

--- a/charts/templates/server-repository/reset-job.yaml
+++ b/charts/templates/server-repository/reset-job.yaml
@@ -12,7 +12,7 @@ spec:
       backoffLimit: 0
       template:
         spec:
-          serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
+          serviceAccountName: {{ printf "%s-%s" .Chart.Name "prvw-reset-sa" | trimSuffix "-"| trunc 52 }}
           restartPolicy: Never
           containers:
           - name: reset
@@ -21,9 +21,11 @@ spec:
             command:
             - /bin/bash
             - -c
-            - POD=$(kubectl get pods -l app.kubernetes.io/name=sourcify-server-repository -n sourcify | tail -1 | awk '{print $1}'); k exec -it -n sourcify $POD -- ./hedera-reset-docker.sh previewnet
-# This job requires a special service account with specific permissions to accomplish this task
+            - POD=$(kubectl get pods -l app.kubernetes.io/name=sourcify-server-repository -n sourcify | tail -1 | awk '{print $1}'); kubectl exec -it -n sourcify $POD -- ./hedera-reset-docker.sh previewnet
+{{- end }}
+
 ---
+{{- if .Values.reset.previewnet_reset.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -34,7 +36,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
+
 ---
+{{- if .Values.reset.previewnet_reset.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -52,11 +57,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
+{{- end }}
+
 ---
+{{- if .Values.reset.previewnet_reset.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ printf "%s-%s" .Chart.Name "prvw-reset-role-binding" | trimSuffix "-"| trunc 52 }}
+  name: {{ printf "%s-%s" .Chart.Name "prvw-reset-rolebinding" | trimSuffix "-"| trunc 52 }}
   labels:
     {{- include "sourcify.labels" . | nindent 4 }}
   {{- with .Values.serverRepository.serviceAccount.annotations }}
@@ -67,9 +75,13 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ printf "%s-%s" .Chart.Name "prvw-reset-role" | trimSuffix "-"| trunc 52 }}
-
+subjects:
+  - kind: ServiceAccount
+    name: {{ printf "%s-%s" .Chart.Name "prvw-reset-sa" | trimSuffix "-"| trunc 52 }}
+    namespace: {{ .Release.Namespace }}  
 {{- end }}
 
+---
 # Testnet reset job
 {{- if .Values.reset.testnet_reset.enabled }}
 apiVersion: batch/v1
@@ -85,7 +97,7 @@ spec:
       backoffLimit: 0
       template:
         spec:
-          serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
+          serviceAccountName: {{ printf "%s-%s" .Chart.Name "tsnt-reset-sa" | trimSuffix "-"| trunc 52 }}
           restartPolicy: Never
           containers:
           - name: reset
@@ -94,10 +106,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - POD=$(kubectl get pods -l app.kubernetes.io/name=sourcify-server-repository -n sourcify | tail -1 | awk '{print $1}'); k exec -it -n sourcify $POD -- ./hedera-reset-docker.sh testnet
-
-# This job requires a special service account with specific permissions to accomplish this task
+            - POD=$(kubectl get pods -l app.kubernetes.io/name=sourcify-server-repository -n sourcify | tail -1 | awk '{print $1}'); kubectl exec -it -n sourcify $POD -- ./hedera-reset-docker.sh testnet
 ---
+# This job requires a special service account with specific permissions to accomplish this task
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -141,4 +152,8 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-role" | trimSuffix "-"| trunc 52 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ printf "%s-%s" .Chart.Name "tsnt-reset-sa" | trimSuffix "-"| trunc 52 }}
+    namespace: {{ .Release.Namespace }}    
 {{- end }}

--- a/charts/templates/server-repository/reset-job.yaml
+++ b/charts/templates/server-repository/reset-job.yaml
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           serviceAccountName: {{ template "sourcify.serverRepository.serviceAccountName" . }}
-          restartPolicy: Never
+          restartPolicy: Never        
           containers:
           - name: reset
             image: "{{ .Values.reset.image.repository }}:{{ .Values.reset.image.tag }}"
@@ -21,7 +21,14 @@ spec:
             command:
             - /bin/sh
             - -c
-            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh previewnet
+            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset-docker.sh ; chmod +x hedera-reset-docker.sh ; ./hedera-reset-docker.sh previewnet
+            volumeMounts:
+              - name: {{ .Chart.Name }}
+                mountPath: /data              
+          volumes:
+            - name: {{ .Chart.Name }}
+              persistentVolumeClaim:
+                claimName: {{ template "sourcify.name" . }}-pvc
 {{- end }}
 
 ---
@@ -48,5 +55,5 @@ spec:
             command:
             - /bin/sh
             - -c
-            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset.sh ; chmod +x hedera-reset.sh ; ./hedera-reset.sh testnet
+            - wget https://raw.githubusercontent.com/hashgraph/hedera-sourcify/main/scripts/hedera-reset-docker.sh ; chmod +x hedera-reset-docker.sh ; ./hedera-reset-dcoker.sh testnet
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -159,7 +159,7 @@ reset:
     enabled: false  
   ## Set default immage repository, tag, and pull policy
   image:
-    repository: "apline/curl"
-    tag: "8.4.0"
+    repository: "bitnami/kubectl"
+    tag: "1.28.7"
     pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
**Description**:
This PR modifies the reset job.  The reset job has to be run via mounting the PVC that is in use so that the correct filesystem locations are being reset.  There is a limitation in the CSI driver (aka `google-filestore-driver` in GCP Log explorer) where the driver has a subsystem puts locks on the volume mapped to the pod; this makes it impossible to get the volume to attach to a secondary pod on the same node where the server-repository lives .  This adding a secondary pod on the same node where the PVC is `bound` is documented as a working solution but the subsystem has a different setup.

Because of the limitation above, the reset job now runs `kubectl` to get the running server-repository pod, `exec`s into the pod and triggers the reset script.  There is a reset job for both previewnet and testnet

**Related issue(s)**:

Fixes #43 

**Notes for reviewer**:
These are the logs from the test environment run of this:
```
Defaulted container "sourcify-server" out of: sourcify-server, sourcify-repository
Unable to use a TTY - input is not a terminal or the right kind of file
Resetting Hedera previewnet (Chain ID: 297)
  /data/contracts/partial_match/297 does not exist
  /data/contracts/full_match/297 does not exist
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
