### PR TITLE
feat: Update chart to support upstream images

### DIFF
--- a/charts/templates/server-repository/configmap.yaml
+++ b/charts/templates/server-repository/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- if .Values.serverRepository.annotations }}
   annotations:
   {{ toYaml .Values.serverRepository.annotations | indent 4 }}
-  {{- end }}    
+  {{- end }}
 data:
   REPOSITORY_PATH: {{ .Values.serverRepository.config.REPOSITORY_PATH }}
   SERVER_URL: {{ .Values.serverRepository.config.SERVER_URL }}
@@ -20,7 +20,7 @@ data:
   TESTING: {{ .Values.serverRepository.config.TESTING | quote }}
   NODE_ENV: {{ .Values.serverRepository.config.NODE_ENV | default "development" }}
   UI_DOMAIN_NAME: {{ .Values.serverRepository.config.UI_DOMAIN_NAME }}
-
+  SOURCIFY_SERVER: {{ .Values.serverRepository.config.SERVER_URL }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -36,3 +36,19 @@ metadata:
 data:
   config.json: |-
   {{- .Values.serverRepository.config.repository | toJson  | nindent 4 }}
+  servers.yaml: |-
+  {{- .Values.serverRepository.config.servers | toYaml | nindent 4 }}
+  sourcify-chains.json: |-
+  {{- .Values.serverRepository.config.sourcifyChains | toJson | nindent 4 }}
+  local.js: |
+    module.exports = {
+      corsAllowedOrigins: [
+          /^https?:\/\/(?:.+\.)?sourcify.dev$/, // sourcify.dev and subdomains
+          /^https?:\/\/(?:.+\.)?sourcify.eth$/, // sourcify.eth and subdomains
+          /^https?:\/\/(?:.+\.)?sourcify.eth.link$/, // sourcify.eth.link and subdomains
+          /^https?:\/\/(?:.+\.)?ipfs.dweb.link$/, // dweb links used by Brave browser etc.
+          /^https?:\/\/(?:.+\.)?hedera-devops.com$/, // swirldslabs-devops
+          /^https?:\/\/(?:.+\.)?hashscan.io$/, // hashscan
+          process.env.NODE_ENV !== "production" && /^https?:\/\/localhost(?::\d+)?$/, // localhost on any port /^{{ .Values.serverRepository.config.SERVER_URL }}$/
+      ],
+    };

--- a/charts/templates/server-repository/configmap.yaml
+++ b/charts/templates/server-repository/configmap.yaml
@@ -10,16 +10,13 @@ metadata:
   {{ toYaml .Values.serverRepository.annotations | indent 4 }}
   {{- end }}
 data:
-  REPOSITORY_PATH: {{ .Values.serverRepository.config.REPOSITORY_PATH }}
   SERVER_URL: {{ .Values.serverRepository.config.SERVER_URL }}
   REPOSITORY_SERVER_URL: {{ .Values.serverRepository.config.REPOSITORY_SERVER_URL }}
   SERVER_PORT: {{ .Values.serverRepository.service.server.port | quote }}
   SERVER_EXTERNAL_PORT: {{ .Values.serverRepository.service.server.port | quote }}
   REPOSITORY_SERVER_PORT: {{ .Values.serverRepository.service.repository.port | quote }}
   REPOSITORY_SERVER_EXTERNAL_PORT: {{ .Values.serverRepository.service.repository.port | quote }}
-  TESTING: {{ .Values.serverRepository.config.TESTING | quote }}
   NODE_ENV: {{ .Values.serverRepository.config.NODE_ENV | default "development" }}
-  UI_DOMAIN_NAME: {{ .Values.serverRepository.config.UI_DOMAIN_NAME }}
   SOURCIFY_SERVER: {{ .Values.serverRepository.config.SERVER_URL }}
 ---
 apiVersion: v1
@@ -42,13 +39,9 @@ data:
   {{- .Values.serverRepository.config.sourcifyChains | toJson | nindent 4 }}
   local.js: |
     module.exports = {
+      repositoryV1: { path: "/data", },
       corsAllowedOrigins: [
-          /^https?:\/\/(?:.+\.)?sourcify.dev$/, // sourcify.dev and subdomains
-          /^https?:\/\/(?:.+\.)?sourcify.eth$/, // sourcify.eth and subdomains
-          /^https?:\/\/(?:.+\.)?sourcify.eth.link$/, // sourcify.eth.link and subdomains
-          /^https?:\/\/(?:.+\.)?ipfs.dweb.link$/, // dweb links used by Brave browser etc.
           /^https?:\/\/(?:.+\.)?hedera-devops.com$/, // swirldslabs-devops
           /^https?:\/\/(?:.+\.)?hashscan.io$/, // hashscan
-          process.env.NODE_ENV !== "production" && /^https?:\/\/localhost(?::\d+)?$/, // localhost on any port /^{{ .Values.serverRepository.config.SERVER_URL }}$/
       ],
     };

--- a/charts/templates/server-repository/configmap.yaml
+++ b/charts/templates/server-repository/configmap.yaml
@@ -12,10 +12,6 @@ metadata:
 data:
   SERVER_URL: {{ .Values.serverRepository.config.SERVER_URL }}
   REPOSITORY_SERVER_URL: {{ .Values.serverRepository.config.REPOSITORY_SERVER_URL }}
-  SERVER_PORT: {{ .Values.serverRepository.service.server.port | quote }}
-  SERVER_EXTERNAL_PORT: {{ .Values.serverRepository.service.server.port | quote }}
-  REPOSITORY_SERVER_PORT: {{ .Values.serverRepository.service.repository.port | quote }}
-  REPOSITORY_SERVER_EXTERNAL_PORT: {{ .Values.serverRepository.service.repository.port | quote }}
   NODE_ENV: {{ .Values.serverRepository.config.NODE_ENV | default "development" }}
   SOURCIFY_SERVER: "http://{{ template "sourcify.name" . }}-server:5555"
 ---
@@ -31,8 +27,6 @@ metadata:
   {{ toYaml .Values.serverRepository.annotations | indent 4 }}
   {{- end }}
 data:
-  config.json: |-
-  {{- .Values.serverRepository.config.repository | toJson  | nindent 4 }}
   servers.yaml: |-
   {{- .Values.serverRepository.config.servers | toYaml | nindent 4 }}
   sourcify-chains.json: |-

--- a/charts/templates/server-repository/configmap.yaml
+++ b/charts/templates/server-repository/configmap.yaml
@@ -17,7 +17,7 @@ data:
   REPOSITORY_SERVER_PORT: {{ .Values.serverRepository.service.repository.port | quote }}
   REPOSITORY_SERVER_EXTERNAL_PORT: {{ .Values.serverRepository.service.repository.port | quote }}
   NODE_ENV: {{ .Values.serverRepository.config.NODE_ENV | default "development" }}
-  SOURCIFY_SERVER: {{ .Values.serverRepository.config.SERVER_URL }}
+  SOURCIFY_SERVER: "http://{{ template "sourcify.name" . }}-server:5555"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/templates/server-repository/deployment.yaml
+++ b/charts/templates/server-repository/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- if .Values.serverRepository.annotations }}
   annotations:
   {{ toYaml .Values.serverRepository.annotations | indent 4 }}
-  {{- end }}    
+  {{- end }}
 spec:
   {{- if not .Values.serverRepository.autoscaling.enabled }}
   replicas: {{ .Values.serverRepository.replicaCount }}
@@ -34,12 +34,12 @@ spec:
       {{- if .Values.serverRepository.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.serverRepository.podSecurityContext | nindent 8 }}
-      {{- end }}  
-      containers:        
+      {{- end }}
+      containers:
         - name: {{ printf "%s-%s" .Chart.Name "server" }}
           securityContext:
             {{- toYaml .Values.serverRepository.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.serverRepository.image.server.tag | default "server-latest" }}"
+          image: "{{ .Values.serverRepository.image.server.repository }}:{{ .Values.serverRepository.image.server.tag | default "server-latest" }}"
           imagePullPolicy: {{ .Values.serverRepository.image.pullPolicy }}
           envFrom:
             - configMapRef:
@@ -58,7 +58,7 @@ spec:
               path: /health
               port: serverport
             periodSeconds: 10
-            failureThreshold: 6            
+            failureThreshold: 6
           {{- if .Values.serverRepository.server.resources }}
           resources:
             {{- toYaml .Values.serverRepository.server.resources | nindent 12 }}
@@ -66,14 +66,23 @@ spec:
           volumeMounts:
             - name: {{ .Chart.Name }}
               mountPath: /data
+            - name: {{ printf "%s-%s" .Chart.Name "repository" }}
+              mountPath: /home/app/services/server/dist/config/local.js
+              subPath: local.js
+            - name: {{ printf "%s-%s" .Chart.Name "repository" }}
+              mountPath: /home/app/services/server/dist/sourcify-chains.json
+              subPath: sourcify-chains.json
+            - name: {{ printf "%s-%s" .Chart.Name "repository" }}
+              mountPath: /home/app/services/server/dist/servers.yaml
+              subPath: servers.yaml
         - name: {{ printf "%s-%s" .Chart.Name "repository" }}
           securityContext:
             {{- toYaml .Values.serverRepository.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.serverRepository.image.repository.tag | default "repository-latest" }}"
+          image: "{{ .Values.serverRepository.image.repository.repository }}:{{ .Values.serverRepository.image.repository.tag | default "repository-latest" }}"
           imagePullPolicy: {{ .Values.serverRepository.image.pullPolicy }}
           envFrom:
             - configMapRef:
-                name: {{ template "sourcify.name" . }}          
+                name: {{ template "sourcify.name" . }}
           ports:
             - name: repositoryport
               containerPort: {{ .Values.serverRepository.service.repository.port }}
@@ -87,7 +96,7 @@ spec:
             httpGet:
               path: /select-contract/health
               port: repositoryport
-            periodSeconds: 10             
+            periodSeconds: 10
           {{- if .Values.serverRepository.repository.resources }}
           resources:
             {{- toYaml .Values.serverRepository.repository.resources | nindent 12 }}
@@ -98,7 +107,7 @@ spec:
               readOnly: true
             - name: {{ printf "%s-%s" .Chart.Name "repository" }}
               mountPath: /redirects/config.json
-              subPath: config.json                         
+              subPath: config.json
       {{- if .Values.serverRepository.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.serverRepository.nodeSelector | nindent 8 }}
@@ -117,11 +126,11 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "sourcify.name" . }}-pvc
         {{- else }}
-      volumes:        
+      volumes:
         - name: {{ .Chart.Name }}
           emptyDir: {}
       {{- end }}
         - configMap:
             name: {{ printf "%s-%s" .Chart.Name "repository" }}
-          name: {{ printf "%s-%s" .Chart.Name "repository" }}        
+          name: {{ printf "%s-%s" .Chart.Name "repository" }}
 {{- end -}}

--- a/charts/templates/server-repository/deployment.yaml
+++ b/charts/templates/server-repository/deployment.yaml
@@ -105,9 +105,6 @@ spec:
             - name: {{ .Chart.Name }}
               mountPath: /data
               readOnly: true
-            - name: {{ printf "%s-%s" .Chart.Name "repository" }}
-              mountPath: /redirects/config.json
-              subPath: config.json
       {{- if .Values.serverRepository.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.serverRepository.nodeSelector | nindent 8 }}

--- a/charts/templates/ui/deployment.yaml
+++ b/charts/templates/ui/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- if .Values.ui.annotations }}
   annotations:
   {{ toYaml .Values.ui.annotations | indent 4 }}
-  {{- end }}    
+  {{- end }}
 spec:
   {{- if not .Values.ui.autoscaling.enabled }}
   replicas: {{ .Values.ui.replicaCount }}
@@ -34,7 +34,7 @@ spec:
       {{- if .Values.ui.podSecurityContext}}
       securityContext:
         {{- toYaml .Values.ui.podSecurityContext | nindent 8 }}
-      {{- end }}  
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-ui
           env:
@@ -42,7 +42,7 @@ spec:
             value: {{ .Values.ui.env.UI_DOMAIN_NAME }}
           securityContext:
             {{- toYaml .Values.ui.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.ui.image.tag | default "ui-latest" }}"
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default "ui-latest" }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           ports:
             - name: http
@@ -59,7 +59,7 @@ spec:
       volumes:
       - configMap:
           name: {{ printf "%s-%s" .Chart.Name "ui" }}
-        name: {{ printf "%s-%s" .Chart.Name "ui" }}                          
+        name: {{ printf "%s-%s" .Chart.Name "ui" }}
       {{- if .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.ui.nodeSelector | nindent 8 }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -77,12 +77,6 @@ serverRepository:
     SERVER_URL: "http://127.0.0.1:5555"
     REPOSITORY_SERVER_URL: "http://127.0.0.1:10000"
     NODE_ENV: "production"
-    repository:
-      {
-      "SERVER_URL": "http://127.0.0.1:5555",
-      "REPOSITORY_SERVER_URL": "http://127.0.0.1:10000",
-      "EXPLORER_URL": "http://127.0.0.1:8080",
-      }
     servers:
       - description: The current REST API server
         url: ""

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -27,6 +27,18 @@ serverRepository:
   podAnnotations: {}
   podSecurityContext: {}
 
+  ## server-repository resources configuration
+  repository:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  server:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1024Mi
+
   ## server-repository service configuration
   service:
     server:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -108,13 +108,6 @@ serverRepository:
         "297": {
           "sourcifyName": "Hedera Previewnet",
           "supported": true
-        },
-        "298": {
-          "sourcifyName": "Hedera Localnet",
-          "supported": true,
-          "rpc": [
-            "http://host.docker.internal:7546"
-          ]
         }
       }
 ui:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,8 +1,6 @@
 nameoOverride: ""
 fullnameOverride: ""
 imagePullSecrets: []
-image:
-  repository: "ghcr.io/hashgraph/hedera-sourcify"
 
 serverRepository:
   ## Deploy sourcify server-repository
@@ -41,9 +39,11 @@ serverRepository:
   ## server-repository image configuration, image repository is defined in the global image section above
   image:
     server:
-      tag: "server-latest"
+      repository: ghcr.io/hashgraph/hedera-sourcify/server
+      tag: "test"
     repository:
-      tag: "repository-latest"  
+      repository: ghcr.io/hashgraph/hedera-sourcify/repository
+      tag: "test"
     pullPolicy: "IfNotPresent"
 
   ## server-repository serviceAccount creation and configuration
@@ -86,7 +86,37 @@ serverRepository:
       "REPOSITORY_SERVER_URL": "http://127.0.0.1:10000",
       "EXPLORER_URL": "http://127.0.0.1:8080",
       }
-
+    servers:
+      - description: The current REST API server
+        url: ""
+      - description: The production REST API server
+        url: "https://server-verify.hashscan.io"
+      - description: The staging REST API server
+        url: "https://server-sourcify.hedera-devops.com"
+      - description: Local development server address on default port 5555
+        url: "http://localhost:5555"
+    sourcifyChains:
+      {
+        "295": {
+          "sourcifyName": "Hedera Mainnet",
+          "supported": true
+        },
+        "296": {
+          "sourcifyName": "Hedera Testnet",
+          "supported": true
+        },
+        "297": {
+          "sourcifyName": "Hedera Previewnet",
+          "supported": true
+        },
+        "298": {
+          "sourcifyName": "Hedera Localnet",
+          "supported": true,
+          "rpc": [
+            "http://host.docker.internal:7546"
+          ]
+        }
+      }
 ui:
   ## Deploy sourcify ui
   enabled: true
@@ -119,7 +149,8 @@ ui:
 
   ## UI image configuration, image repository is defined in the global image section above
   image:
-    tag: "ui-latest"
+    repository: ghcr.io/hashgraph/hedera-sourcify/ui
+    tag: "test"
     pullPolicy: "IfNotPresent"
 
   ## UI serviceAccount creation and configuration
@@ -152,14 +183,13 @@ ui:
 
 reset:
   ## Previewnet reset job, default is to disable
-  previewnet_reset: 
+  previewnet_reset:
     enabled: false
   ## Testnet reset job, default is to disable
   testnet_reset:
-    enabled: false  
+    enabled: false
   ## Set default immage repository, tag, and pull policy
   image:
     repository: "bitnami/kubectl"
     tag: "1.28.7"
     pullPolicy: "IfNotPresent"
-

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -40,10 +40,10 @@ serverRepository:
   image:
     server:
       repository: ghcr.io/hashgraph/hedera-sourcify/server
-      tag: "test"
+      tag: "main"
     repository:
       repository: ghcr.io/hashgraph/hedera-sourcify/repository
-      tag: "test"
+      tag: "main"
     pullPolicy: "IfNotPresent"
 
   ## server-repository serviceAccount creation and configuration
@@ -140,7 +140,7 @@ ui:
   ## UI image configuration, image repository is defined in the global image section above
   image:
     repository: ghcr.io/hashgraph/hedera-sourcify/ui
-    tag: "test"
+    tag: "main"
     pullPolicy: "IfNotPresent"
 
   ## UI serviceAccount creation and configuration

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -74,12 +74,9 @@ serverRepository:
 
   ## Configurations for the server-repository containers
   config:
-    REPOSITORY_PATH: "/data"
     SERVER_URL: "http://127.0.0.1:5555"
     REPOSITORY_SERVER_URL: "http://127.0.0.1:10000"
-    TESTING: true
-    NODE_ENV: "development"
-    UI_DOMAIN_NAME: verify.example.com
+    NODE_ENV: "production"
     repository:
       {
       "SERVER_URL": "http://127.0.0.1:5555",


### PR DESCRIPTION
This PR updates the sourcify chart with changes to support using upstream images. The changes are as follows:

- add servers.yaml, sourcify-chains.json, and local.js as Configmaps and mount them to the server container.
- Rework container image structure in both values.yaml and the corresponding deployments.
- Some minor linting of trailing spaces & newlines.