### PR TITLE
build: use `large` self-hosted runner to build and push images

### DIFF
--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   docker-image-publish:
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: [self-hosted, Linux, large, ephemeral]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
**Description**:

Use `large` runner to fix CI image build.

Related to https://github.com/hashgraph/hedera-sourcify/pull/199.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #196.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
