### PR TITLE
build: setup cache to build images in CI

### DIFF
--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -83,26 +83,26 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/ui:${{env.TAG}}
 
-      # - name: Build and push SERVER image
-      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-      #   with:
-      #     cache-from: type=gha,scope=build-server
-      #     cache-to: type=gha,mode=max,scope=build-server
+      - name: Build and push SERVER image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          cache-from: type=gha,scope=build-server
+          cache-to: type=gha,mode=max,scope=build-server
 
-      #     context: ./sourcify
+          context: ./sourcify
 
-      #     # The `scripts` context is used to `COPY` the reset network script into the `server` container.
-      #     # Use `additional_contexts` to access the `scripts` folder outside main context.
-      #     # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
-      #     build-contexts: |
-      #       scripts=./scripts
+          # The `scripts` context is used to `COPY` the reset network script into the `server` container.
+          # Use `additional_contexts` to access the `scripts` folder outside main context.
+          # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
+          build-contexts: |
+            scripts=./scripts
 
-      #     # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
-      #     # It adds instructions to include the reset network script into the container.
-      #     file: ./Dockerfile.server
-      #     platforms: linux/amd64, linux/arm64
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
+          # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
+          # It adds instructions to include the reset network script into the container.
+          file: ./Dockerfile.server
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
 
       # - name: Build and Push REPOSITORY Image
       #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -74,6 +74,8 @@ jobs:
       - name: Build and push UI image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: ./ui
           file: ./ui/Dockerfile
           platforms: linux/amd64, linux/arm64
@@ -83,6 +85,8 @@ jobs:
       - name: Build and push SERVER image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: ./sourcify
 
           # The `scripts` context is used to `COPY` the reset network script into the `server` container.
@@ -101,6 +105,8 @@ jobs:
       - name: Build and Push REPOSITORY Image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: ./h5ai-nginx
 
           # From https://github.com/ethereum/sourcify/issues/1385

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -82,25 +82,25 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/ui:${{env.TAG}}
 
-      # - name: Build and push SERVER image
-      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-      #   with:
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
-      #     context: ./sourcify
+      - name: Build and push SERVER image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: ./sourcify
 
-      #     # The `scripts` context is used to `COPY` the reset network script into the `server` container.
-      #     # Use `additional_contexts` to access the `scripts` folder outside main context.
-      #     # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
-      #     build-contexts: |
-      #       scripts=./scripts
+          # The `scripts` context is used to `COPY` the reset network script into the `server` container.
+          # Use `additional_contexts` to access the `scripts` folder outside main context.
+          # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
+          build-contexts: |
+            scripts=./scripts
 
-      #     # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
-      #     # It adds instructions to include the reset network script into the container.
-      #     file: ./Dockerfile.server
-      #     platforms: linux/amd64, linux/arm64
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
+          # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
+          # It adds instructions to include the reset network script into the container.
+          file: ./Dockerfile.server
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
 
       # - name: Build and Push REPOSITORY Image
       #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -104,25 +104,25 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
 
-      # - name: Build and Push REPOSITORY Image
-      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-      #   with:
-      #     cache-from: type=gha,scope=build-repository
-      #     cache-to: type=gha,mode=max,scope=build-repository
+      - name: Build and Push REPOSITORY Image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          cache-from: type=gha,scope=build-repository
+          cache-to: type=gha,mode=max,scope=build-repository
 
-      #     context: ./h5ai-nginx
+          context: ./h5ai-nginx
 
-      #     # From https://github.com/ethereum/sourcify/issues/1385
-      #     #
-      #     # The `repository` service provides a link to open each verified contract in Remix.
-      #     # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
-      #     # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
-      #     # 
-      #     # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
-      #     # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
-      #     build-args: |
-      #       HIDE_OPEN_IN_REMIX=1
-      #     file: ./h5ai-nginx/Dockerfile
-      #     platforms: linux/amd64, linux/arm64
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}
+          # From https://github.com/ethereum/sourcify/issues/1385
+          #
+          # The `repository` service provides a link to open each verified contract in Remix.
+          # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
+          # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
+          # 
+          # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
+          # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
+          build-args: |
+            HIDE_OPEN_IN_REMIX=1
+          file: ./h5ai-nginx/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -102,24 +102,24 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
 
-      # - name: Build and Push REPOSITORY Image
-      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-      #   with:
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
-      #     context: ./h5ai-nginx
+      - name: Build and Push REPOSITORY Image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: ./h5ai-nginx
 
-      #     # From https://github.com/ethereum/sourcify/issues/1385
-      #     #
-      #     # The `repository` service provides a link to open each verified contract in Remix.
-      #     # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
-      #     # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
-      #     # 
-      #     # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
-      #     # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
-      #     build-args: |
-      #       HIDE_OPEN_IN_REMIX=1
-      #     file: ./h5ai-nginx/Dockerfile
-      #     platforms: linux/amd64, linux/arm64
-      #     push: true
-      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}
+          # From https://github.com/ethereum/sourcify/issues/1385
+          #
+          # The `repository` service provides a link to open each verified contract in Remix.
+          # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
+          # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
+          # 
+          # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
+          # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
+          build-args: |
+            HIDE_OPEN_IN_REMIX=1
+          file: ./h5ai-nginx/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -74,8 +74,9 @@ jobs:
       - name: Build and push UI image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=build-ui
+          cache-to: type=gha,mode=max,scope=build-ui
+
           context: ./ui
           file: ./ui/Dockerfile
           platforms: linux/amd64, linux/arm64
@@ -85,8 +86,9 @@ jobs:
       - name: Build and push SERVER image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=build-server
+          cache-to: type=gha,mode=max,scope=build-server
+
           context: ./sourcify
 
           # The `scripts` context is used to `COPY` the reset network script into the `server` container.
@@ -105,8 +107,9 @@ jobs:
       - name: Build and Push REPOSITORY Image
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=build-repository
+          cache-to: type=gha,mode=max,scope=build-repository
+
           context: ./h5ai-nginx
 
           # From https://github.com/ethereum/sourcify/issues/1385

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -82,44 +82,44 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/ui:${{env.TAG}}
 
-      - name: Build and push SERVER image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          context: ./sourcify
+      # - name: Build and push SERVER image
+      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      #   with:
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
+      #     context: ./sourcify
 
-          # The `scripts` context is used to `COPY` the reset network script into the `server` container.
-          # Use `additional_contexts` to access the `scripts` folder outside main context.
-          # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
-          build-contexts: |
-            scripts=./scripts
+      #     # The `scripts` context is used to `COPY` the reset network script into the `server` container.
+      #     # Use `additional_contexts` to access the `scripts` folder outside main context.
+      #     # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
+      #     build-contexts: |
+      #       scripts=./scripts
 
-          # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
-          # It adds instructions to include the reset network script into the container.
-          file: ./Dockerfile.server
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
+      #     # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
+      #     # It adds instructions to include the reset network script into the container.
+      #     file: ./Dockerfile.server
+      #     platforms: linux/amd64, linux/arm64
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
 
-      - name: Build and Push REPOSITORY Image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          context: ./h5ai-nginx
+      # - name: Build and Push REPOSITORY Image
+      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      #   with:
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
+      #     context: ./h5ai-nginx
 
-          # From https://github.com/ethereum/sourcify/issues/1385
-          #
-          # The `repository` service provides a link to open each verified contract in Remix.
-          # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
-          # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
-          # 
-          # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
-          # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
-          build-args: |
-            HIDE_OPEN_IN_REMIX=1
-          file: ./h5ai-nginx/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}
+      #     # From https://github.com/ethereum/sourcify/issues/1385
+      #     #
+      #     # The `repository` service provides a link to open each verified contract in Remix.
+      #     # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
+      #     # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
+      #     # 
+      #     # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
+      #     # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
+      #     build-args: |
+      #       HIDE_OPEN_IN_REMIX=1
+      #     file: ./h5ai-nginx/Dockerfile
+      #     platforms: linux/amd64, linux/arm64
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -83,46 +83,46 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}/ui:${{env.TAG}}
 
-      - name: Build and push SERVER image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          cache-from: type=gha,scope=build-server
-          cache-to: type=gha,mode=max,scope=build-server
+      # - name: Build and push SERVER image
+      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      #   with:
+      #     cache-from: type=gha,scope=build-server
+      #     cache-to: type=gha,mode=max,scope=build-server
 
-          context: ./sourcify
+      #     context: ./sourcify
 
-          # The `scripts` context is used to `COPY` the reset network script into the `server` container.
-          # Use `additional_contexts` to access the `scripts` folder outside main context.
-          # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
-          build-contexts: |
-            scripts=./scripts
+      #     # The `scripts` context is used to `COPY` the reset network script into the `server` container.
+      #     # Use `additional_contexts` to access the `scripts` folder outside main context.
+      #     # See https://docs.docker.com/compose/compose-file/build/#additional_contexts for more details.
+      #     build-contexts: |
+      #       scripts=./scripts
 
-          # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
-          # It adds instructions to include the reset network script into the container.
-          file: ./Dockerfile.server
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
+      #     # The `Dockerfile.server` used here is basically the same as the one provided by Sourcify.
+      #     # It adds instructions to include the reset network script into the container.
+      #     file: ./Dockerfile.server
+      #     platforms: linux/amd64, linux/arm64
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/server:${{env.TAG}}
 
-      - name: Build and Push REPOSITORY Image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
-        with:
-          cache-from: type=gha,scope=build-repository
-          cache-to: type=gha,mode=max,scope=build-repository
+      # - name: Build and Push REPOSITORY Image
+      #   uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
+      #   with:
+      #     cache-from: type=gha,scope=build-repository
+      #     cache-to: type=gha,mode=max,scope=build-repository
 
-          context: ./h5ai-nginx
+      #     context: ./h5ai-nginx
 
-          # From https://github.com/ethereum/sourcify/issues/1385
-          #
-          # The `repository` service provides a link to open each verified contract in Remix.
-          # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
-          # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
-          # 
-          # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
-          # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
-          build-args: |
-            HIDE_OPEN_IN_REMIX=1
-          file: ./h5ai-nginx/Dockerfile
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}
+      #     # From https://github.com/ethereum/sourcify/issues/1385
+      #     #
+      #     # The `repository` service provides a link to open each verified contract in Remix.
+      #     # However, for public self-hosted Sourcify instances (like in the case of Hedera) the _Open repo in Remix_ link does not work,
+      #     # given the Remix plugin only fetches contracts from https://repo.sourcify.dev.
+      #     # 
+      #     # When `HIDE_OPEN_IN_REMIX` is set to 1, a patch to remove the link is applied.
+      #     # See https://github.com/sourcifyeth/h5ai-nginx/pull/5 for more details.
+      #     build-args: |
+      #       HIDE_OPEN_IN_REMIX=1
+      #     file: ./h5ai-nginx/Dockerfile
+      #     platforms: linux/amd64, linux/arm64
+      #     push: true
+      #     tags: ${{ env.REGISTRY }}/${{ github.repository }}/repository:${{env.TAG}}


### PR DESCRIPTION
**Description**:

This PR setups `docker/build-push-action` cache in the workflow to improve building images in CI.

After the cache is filled, most of the `docker/build-push-action` step output should look like

```
#43 [linux/amd64 production 11/12] RUN npm ci --workspace=sourcify-server --include-workspace-root --omit=dev
#43 CACHED
```

**This reduces the workflow runtime from about an hour to a about minute when hitting the cache!**

> [!IMPORTANT]
> Each `docker/build-push-action` step needs to setup its [own scope](https://github.com/moby/buildkit/issues/2885) to avoid overwriting its cache between steps. The [docs](https://github.com/moby/buildkit?tab=readme-ov-file#github-actions-cache-experimental) regarding `scope` are not clear about this behavior.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #203.

**Notes for reviewer**:

This feature was implemented with several trials and errors to get these settings right. Each `docker/build-push-action` step was enabled one at a time to ensure the cache was filled successfully. In subsequent runs I could verify that the cache for a previous run was used.

<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
