### PR TITLE
ci: update workflows to use latitude.sh based runners

### DIFF
--- a/.github/workflows/chart-lint-test.yaml
+++ b/.github/workflows/chart-lint-test.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint-test:
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: smart-contracts-linux-medium
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1

--- a/.github/workflows/flow-pr-title-check.yaml
+++ b/.github/workflows/flow-pr-title-check.yaml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: smart-contracts-linux-medium
     permissions:
       statuses: write
     steps:

--- a/.github/workflows/push-images.yaml
+++ b/.github/workflows/push-images.yaml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   docker-image-publish:
-    runs-on: [self-hosted, Linux, large, ephemeral]
+    runs-on: smart-contracts-linux-large
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
 
   server-ganache:
     name: server over Ganache integration tests
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
@@ -45,7 +45,7 @@ jobs:
 
   server-local-node:
     name: server over Hedera's local node integration tests
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1


### PR DESCRIPTION
## Description

This pull request changes the following:

* Updates CI workflows to use the Latitude.sh self-hosted runners.

### Related Issues

* Closes #234 
