### PR TITLE
chore: rename devops-ci to platform-ci

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,25 +12,25 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protections for nvm
-**/.nvmrc                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/.nvmrc                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
 
 # Typescript Protection
-**/package.json                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
-**/package-lock.json                            @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
-**/tsconfig.json                                @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/package.json                                 @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/package-lock.json                            @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/tsconfig.json                                @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
 
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
-**/LICENSE                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
+/README.md                                      @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/LICENSE                                      @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
-**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/.gitignore                                   @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+**/.gitignore.*                                 @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers  @hashgraph/hedera-smart-contracts @hashgraph/dev-experience


### PR DESCRIPTION
Description:

Rename devops-ci to platform-ci and devops-ci-committers to platform-ci-committers

Related Issue(s):

Fixes #278
