### PR TITLE
chore: limit number of approvers on workflows folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 /.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
-/.github/dependabot.yml                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+/.github/dependabot.yml                         @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
 
 
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,8 +20,8 @@
 **/tsconfig.json                                @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,8 +20,10 @@
 **/tsconfig.json                                @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
 /.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers
+/.github/dependabot.yml                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts @hashgraph/dev-experience
+
 
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)


### PR DESCRIPTION
**Description**:

Limit the workflow folder to only platform-ci, platform-ci-committers, and release engineering managers group.

**Related Issue(s)**:

Fixes #278
